### PR TITLE
Added ability to figure out if a parsed menu has a selected item in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 coverage/
 composer.lock
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Make an API call for the menu
 
         // Get a final array to display the main menu
         $main_menu = $parseMenu->parse($menus[2], $menu_config);
+        
+        // Check if the page was found in the menu
+        $page_found = $parseMenu->hasSelected();
 
         // Just display the first level in the header
         $top_menu_config = array(

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -11,14 +11,19 @@ use Waynestate\Menuitems\InvalidSkipLevelsException;
 class ParseMenu implements ParserInterface
 {
     /**
-     * @var
+     * @var array
      */
     protected $menu;
 
     /**
-     * @var
+     * @var array
      */
     protected $path = array();
+
+    /**
+     * @var boolean
+     */
+    protected $has_selected = false;
 
     /**
      * @param array $menu
@@ -31,6 +36,9 @@ class ParseMenu implements ParserInterface
     {
         // Set the menu locally
         $this->menu = $menu;
+
+        // Reset the selected state
+        $this->has_selected = false;
 
         // Set a default levels to skip from root
         $skip = isset($config['skip_levels']) ? (int)$config['skip_levels'] : 0;
@@ -61,6 +69,14 @@ class ParseMenu implements ParserInterface
 
         // The menu now has been modified with $config
         return $this->menu;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasSelected()
+    {
+        return $this->has_selected;
     }
 
     /**
@@ -117,6 +133,9 @@ class ParseMenu implements ParserInterface
             if (in_array($item['menu_item_id'], $this->path)) {
                 // This item should be in the selected path
                 $item['is_selected'] = true;
+
+                // Keep track that a selected menu item has been found
+                $this->has_selected = true;
 
                 // If there is a submenu trim it too
                 if (! empty($item['submenu'])) {

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -12,4 +12,9 @@ interface ParserInterface
      * @return array
      */
     public function parse(array &$menu, array $config);
+
+    /**
+     * @return boolean
+     */
+    public function hasSelected();
 }

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -148,6 +148,39 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function hasPageSelected()
+    {
+        // Determine a page to be selected
+        $config = array(
+            'page_selected' => 1
+        );
+
+        // Parse the menu based on the config
+        $this->parser->parse($this->menu, $config);
+
+        // Verify there is a menu item selected in the last parse()
+        $this->assertTrue($this->parser->hasSelected());
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotHavePageSelected()
+    {
+        // Do not select a page
+        $config = array(
+        );
+
+        // Parse the menu based on the config
+        $this->parser->parse($this->menu, $config);
+
+        // There should not be a menu item selected in the last parse()
+        $this->assertFalse($this->parser->hasSelected());
+    }
+
+    /**
+     * @test
+     */
     public function trimNonSelectedMenus()
     {
         // Determine a page to be selected


### PR DESCRIPTION
A possible solution to #1.

``` php
// Get a final array to display the main menu
$main_menu = $parseMenu->parse($menus[2], $menu_config);

// Check if the page was found in the menu
$page_found = $parseMenu->hasSelected();
```

@chrispelzer @robertvrabel Discussion of this possible solution here.

The only thing I am seeing as deceiving at this point is the example in the README. I'm not sure how often that it happens, the `parse()` is being run a second time to slice the already parsed menu to just the first layer (to display on the top bar). But since it the `page_selected` was already run through the first time around the second parse simply needs to do the slice.

With the proposed solution below `$this->has_selected` is being reset on the second `parse()` but `$this->path` isn't and the menu being passed in has the `is_selected` states in tact. Thus checking `$parseMenu->hasSelected()` after the second parse would return a false negative. There is a page selected in the menu.

Maybe that isn't an issue or maybe it is?
