### PR TITLE
Added meta information about the menu to the return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 coverage/
 composer.lock
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ Make an API call for the menu
 
         echo 'Caught exception: '.  $e->getMessage(). "\n";
     }
+    
+Return values
 
+    $main_menu['meta'] = [
+        'has_selected' => boolean, // default: false
+        'depth' => integer, // default: 0
+        'path' => array, // default: array()
+    ]
+    
+    $main_menu['menu'] = [
+        // Array of the menu
+    ]
+    
 Config Options
 
     'page_selected' = Page ID for selection path

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -40,7 +40,6 @@ class ParseMenu implements ParserInterface
         // Base meta information
         $this->meta = array(
             'has_selected' => false,
-            'depth' => 0,
             'path' => $this->path,
         );
 
@@ -79,7 +78,6 @@ class ParseMenu implements ParserInterface
 
         // Updated meta information
         $this->meta['path'] = array_reverse($this->path);
-        $this->meta['depth'] = count($this->path);
 
         // The menu now has been modified with $config
         return array(

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -125,7 +125,12 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // There should be no different in the base and resulting array
-        $this->assertEmpty($this->arrayRecursiveDiff($parsed, $this->menu));
+        $this->assertEmpty($this->arrayRecursiveDiff($parsed['menu'], $this->menu));
+
+        // Meta information should be default
+        $this->assertFalse($parsed['meta']['has_selected']);
+        $this->assertEquals(0, $parsed['meta']['depth']);
+        $this->assertEmpty($parsed['meta']['path']);
     }
 
     /**
@@ -142,7 +147,12 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Verify menu item has a boolean flag
-        $this->assertTrue($parsed[0]['is_selected']);
+        $this->assertTrue($parsed['menu'][0]['is_selected']);
+
+        // Verify meta information matches
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(1, $parsed['meta']['depth']);
+        $this->assertEquals(array(1), array_values($parsed['meta']['path']));
     }
 
     /**
@@ -159,7 +169,12 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Verify the first menu item no longer has submenu items to display
-        $this->assertCount(0, $parsed[0]['submenu']);
+        $this->assertCount(0, $parsed['menu'][0]['submenu']);
+
+        // Verify meta information matches
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(2, $parsed['meta']['depth']);
+        $this->assertEquals(array(2, 7), array_values($parsed['meta']['path']));
     }
 
     /**
@@ -176,9 +191,13 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Verify no main menu items have the is_selected flag
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             $this->assertFalse($item['is_selected']);
         }
+
+        $this->assertFalse($parsed['meta']['has_selected']);
+        $this->assertEquals(0, $parsed['meta']['depth']);
+        $this->assertEmpty($parsed['meta']['path']);
     }
 
     /**
@@ -196,10 +215,14 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Loop through all main level items
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             // Ensure each main item no longer has sub menu items
             $this->assertCount(0, $item['submenu']);
         }
+
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(1, $parsed['meta']['depth']);
+        $this->assertEquals(array(2), array_values($parsed['meta']['path']));
     }
 
     /**
@@ -217,7 +240,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Loop through all main level items
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             // If this item is in the path
             if ($item['is_selected']) {
                 // There should be sub menu items
@@ -227,6 +250,10 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 $this->assertCount(0, $item['submenu']);
             }
         }
+
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(2, $parsed['meta']['depth']);
+        $this->assertEquals(array(1, 4), array_values($parsed['meta']['path']));
     }
 
     /**
@@ -244,10 +271,14 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Loop through all main level items
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             // The parent_id of each of these items should not be the root '0' item
             $this->assertNotEquals(0, $item['parent_id']);
         }
+
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(1, $parsed['meta']['depth']);
+        $this->assertEquals(array(4), array_values($parsed['meta']['path']));
     }
 
     /**
@@ -266,10 +297,14 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Loop through all main level items
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             // There should not be sub menu items
             $this->assertCount(0, $item['submenu']);
         }
+
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(1, $parsed['meta']['depth']);
+        $this->assertEquals(array(9), array_values($parsed['meta']['path']));
     }
 
     /**
@@ -286,10 +321,14 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Loop through all main level items
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             // There should not be sub menu items
             $this->assertCount(0, $item['submenu']);
         }
+
+        $this->assertFalse($parsed['meta']['has_selected']);
+        $this->assertEquals(0, $parsed['meta']['depth']);
+        $this->assertEmpty($parsed['meta']['path']);
     }
 
     /**
@@ -322,7 +361,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Loop through all main level items
-        foreach ($parsed as $item) {
+        foreach ($parsed['menu'] as $item) {
             // If this item is in the path
             if ($item['is_selected']) {
                 // There should be sub menu items
@@ -332,6 +371,10 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 $this->assertCount(0, $item['submenu']);
             }
         }
+
+        $this->assertTrue($parsed['meta']['has_selected']);
+        $this->assertEquals(2, $parsed['meta']['depth']);
+        $this->assertEquals(array(1, 3), array_values($parsed['meta']['path']));
     }
 
     /**

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -129,7 +129,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         // Meta information should be default
         $this->assertFalse($parsed['meta']['has_selected']);
-        $this->assertEquals(0, $parsed['meta']['depth']);
         $this->assertEmpty($parsed['meta']['path']);
     }
 
@@ -151,7 +150,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         // Verify meta information matches
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(1, $parsed['meta']['depth']);
         $this->assertEquals(array(1), array_values($parsed['meta']['path']));
     }
 
@@ -173,7 +171,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         // Verify meta information matches
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(2, $parsed['meta']['depth']);
         $this->assertEquals(array(2, 7), array_values($parsed['meta']['path']));
     }
 
@@ -196,7 +193,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertFalse($parsed['meta']['has_selected']);
-        $this->assertEquals(0, $parsed['meta']['depth']);
         $this->assertEmpty($parsed['meta']['path']);
     }
 
@@ -221,7 +217,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(1, $parsed['meta']['depth']);
         $this->assertEquals(array(2), array_values($parsed['meta']['path']));
     }
 
@@ -252,7 +247,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(2, $parsed['meta']['depth']);
         $this->assertEquals(array(1, 4), array_values($parsed['meta']['path']));
     }
 
@@ -277,7 +271,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(1, $parsed['meta']['depth']);
         $this->assertEquals(array(4), array_values($parsed['meta']['path']));
     }
 
@@ -303,7 +296,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(1, $parsed['meta']['depth']);
         $this->assertEquals(array(9), array_values($parsed['meta']['path']));
     }
 
@@ -327,7 +319,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertFalse($parsed['meta']['has_selected']);
-        $this->assertEquals(0, $parsed['meta']['depth']);
         $this->assertEmpty($parsed['meta']['path']);
     }
 
@@ -373,7 +364,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($parsed['meta']['has_selected']);
-        $this->assertEquals(2, $parsed['meta']['depth']);
         $this->assertEquals(array(1, 3), array_values($parsed['meta']['path']));
     }
 


### PR DESCRIPTION
@robertvrabel @chrispelzer
Per the discussion in: https://github.com/waynestate/parse-menu/pull/2

This will now return an array with two keys from `->parse()`.

``` php
    $main_menu['meta'] = [
        'has_selected' => boolean, // default: false
        'depth' => integer, // default: 0
        'path' => array, // default: array()
    ]

    $main_menu['menu'] = [
        // Array of the parsed menu
    ]
```

Initial set of meta information that I thought would be useful, open to suggestions.

**Questions at this point:**
1. For the test case [`shouldAllowDisplayLevelOneWithoutPageSelection`](https://github.com/waynestate/parse-menu/compare/develop...feature/meta-info?expand=1#diff-2056bc19e659a5234933f9d70d47f344R330), should the 'depth' be `0` or `1`?

Previously, 'depth' is relative to how deep the page selection is, in this new context I am thinking it should be the actual depth of the menu returned. If you both agree, I'll change that code.
