### PR TITLE
'Has Submenu' flag to detect if an menu item has active children

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Return values
 
     $main_menu['meta'] = [
         'has_selected' => boolean, // default: false
+        'has_submenu' => boolean, // default: false
         'depth' => integer, // default: 0
         'path' => array, // default: array()
     ]

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -80,6 +80,12 @@ class ParseMenu implements ParserInterface
         // Updated meta information
         $this->meta['path'] = array_reverse($this->path);
 
+        // If there is a selected item
+        if ($this->meta['has_selected']) {
+            // Check to see if there are any active submenu items
+            $this->meta['has_submenu'] = $this->hasSubMenu(current($this->meta['path']));
+        }
+
         // The menu now has been modified with $config
         return array(
             'meta' => $this->meta,
@@ -232,5 +238,35 @@ class ParseMenu implements ParserInterface
 
         // Should never get to this point
         return $slice_menu;
+    }
+
+    /**
+     * Determine if the top level of a selected path has a submenu to display
+     *
+     * @param $menu_item_id
+     * @return bool
+     */
+    protected function hasSubMenu($menu_item_id)
+    {
+        // Submenu always available with a path > 1
+        if (count($this->meta['path']) > 1)
+            return true;
+
+        // Decide if the first level menu has any visible submenu items
+        foreach ($this->menu as $item) {
+            // Find the desired menu item in the first level
+            if ($item['menu_item_id'] == $menu_item_id) {
+                // Loop through each submenu item
+                foreach ($item['submenu'] as $sub_item) {
+                    // If there is at least one active item
+                    if ($sub_item['is_active'] == true) {
+                        // There is a submenu to display
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -40,6 +40,7 @@ class ParseMenu implements ParserInterface
         // Base meta information
         $this->meta = array(
             'has_selected' => false,
+            'has_submenu' => false,
             'path' => $this->path,
         );
 

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -31,6 +31,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 'menu_id' => 1,
                 'page_id' => 1,
                 'parent_id' => 0,
+                'is_active' => true,
                 'display_name' => 'First',
                 'submenu' => array(
                     array(
@@ -38,6 +39,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                         'menu_id' => 1,
                         'page_id' => 4,
                         'parent_id' => 1,
+                        'is_active' => true,
                         'display_name' => 'Nest One',
                         'submenu' => array(),
                     ),
@@ -46,6 +48,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                         'menu_id' => 1,
                         'page_id' => 5,
                         'parent_id' => 1,
+                        'is_active' => true,
                         'display_name' => 'Nest Two',
                         'submenu' => array(),
                     ),
@@ -54,6 +57,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                         'menu_id' => 1,
                         'page_id' => 6,
                         'parent_id' => 1,
+                        'is_active' => true,
                         'display_name' => 'Nest Three',
                         'submenu' => array(
                             array(
@@ -61,6 +65,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                                 'menu_id' => 1,
                                 'page_id' => 9,
                                 'parent_id' => 5,
+                                'is_active' => true,
                                 'display_name' => 'Nest Nest One',
                                 'submenu' => array(),
                             ),
@@ -69,6 +74,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                                 'menu_id' => 1,
                                 'page_id' => 10,
                                 'parent_id' => 5,
+                                'is_active' => true,
                                 'display_name' => 'Nest Nest Two',
                                 'submenu' => array(),
                             ),
@@ -81,6 +87,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 'menu_id' => 1,
                 'page_id' => 2,
                 'parent_id' => 0,
+                'is_active' => true,
                 'display_name' => 'Second',
                 'submenu' => array(
                     array(
@@ -88,6 +95,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                         'menu_id' => 1,
                         'page_id' => 7,
                         'parent_id' => 2,
+                        'is_active' => false,
                         'display_name' => 'Two Nest One',
                         'submenu' => array(),
                     ),
@@ -96,6 +104,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                         'menu_id' => 1,
                         'page_id' => 8,
                         'parent_id' => 2,
+                        'is_active' => false,
                         'display_name' => 'Two Nest Two',
                         'submenu' => array(),
                     ),
@@ -106,6 +115,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 'menu_id' => 1,
                 'page_id' => 11,
                 'parent_id' => 0,
+                'is_active' => true,
                 'display_name' => 'Third',
                 'submenu' => array(),
             ),
@@ -381,6 +391,57 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         // Parse the menu based on the config
         $parsed = $this->parser->parse($this->menu, $config);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotHaveSubMenuWithNoItems()
+    {
+        // Ensure the page selected should not have a sub menu
+        $config = array(
+            'page_selected' => 9,
+        );
+
+        // Parse the menu based on the config
+        $parsed = $this->parser->parse($this->menu, $config);
+
+        // This page should not have a submenu
+        $this->assertFalse($parsed['meta']['has_submenu']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotHaveSubMenuWithInactiveItems()
+    {
+        // Ensure the page selected should not have a sub menu
+        $config = array(
+            'page_selected' => 2,
+        );
+
+        // Parse the menu based on the config
+        $parsed = $this->parser->parse($this->menu, $config);
+
+        // This page should not have a submenu
+        $this->assertFalse($parsed['meta']['has_submenu']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldHaveSubMenu()
+    {
+        // Ensure the page selected should not have a sub menu
+        $config = array(
+            'page_selected' => 6,
+        );
+
+        // Parse the menu based on the config
+        $parsed = $this->parser->parse($this->menu, $config);
+
+        // This page should not have a submenu
+        $this->assertTrue($parsed['meta']['has_submenu']);
     }
 
     /**

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -400,7 +400,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     {
         // Ensure the page selected should not have a sub menu
         $config = array(
-            'page_selected' => 9,
+            'page_selected' => 11,
         );
 
         // Parse the menu based on the config
@@ -430,7 +430,24 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldHaveSubMenu()
+    public function shouldHaveSubMenuAtLevelOne()
+    {
+        // Ensure the page selected should not have a sub menu
+        $config = array(
+            'page_selected' => 1,
+        );
+
+        // Parse the menu based on the config
+        $parsed = $this->parser->parse($this->menu, $config);
+
+        // This page should not have a submenu
+        $this->assertTrue($parsed['meta']['has_submenu']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldHaveSubMenuAtInteriorLevel()
     {
         // Ensure the page selected should not have a sub menu
         $config = array(


### PR DESCRIPTION
Based on the [need to conditionally show the local menu when navigating to a selected page](https://bitbucket.org/waynestate/generator-foundation5-site/pull-requests/47/dont-show-the-left-menu-unless-we-need-to/diff#comment-10815273).

After `parse()` a `$meta['has_submenu']` boolean will be available.

**False if:**  
1. No selected item in the menu
2. Selected item is on the first level and has no child menu items
3. Selected item is on the first level and has no active child item

**True if:**  
1. Selected item is on the first level and has active child items
2. Selected item is beyond the first level (>1)

@robertvrabel @chrispelzer @breakdancingcat @tomkrupka
Please review the tests and code to ensure my approach is accurate to the desired results. I tried to do this in an existing loop but because of `$skip_levels` and `$display_levels` the detection must happen with the final selection path.
