### PR TITLE
Official stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-menu",
-    "version": "0.2.1",
+    "version": "1.0.0",
     "type": "library",
     "description": "Parse menus from the Wayne State University API",
     "keywords": ["array","parser"],


### PR DESCRIPTION
Keeping in line with [`parse-promos`](https://github.com/waynestate/parse-promos/pull/9), this code is already used on production, let's tag it as stable.
