### PR TITLE
`is_selected` now aways applied & `full_menu` config added

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ Return values
     
 Config Options
 
-    'page_selected' = Page ID for selection path
+    'page_selected' = Page ID for selection path (optional)
     'skip_levels' = Number of levels to skip from the root (requires page_selected)
     'display_levels' = Number of levels to display from the root (requires page_selected, if > 1)
+    'full_menu' = Return the full menu regardless if there is a page selected (boolean, default: false)
     TODO: 'show_levels' = Number of levels to display from the leaf (requires page_selected)
     TODO: 'add_home' = Add 'Home' as the first menu item (this may not be needed)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-menu",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "type": "library",
     "description": "Parse menus from the Wayne State University API",
     "keywords": ["array","parser"],

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -54,7 +54,12 @@ class ParseMenu implements ParserInterface
         if (isset($config['page_selected'])) {
             // Find the first occurrence of the page_id
             $this->path = $this->findPath($this->menu, (int)$config['page_selected']);
+        }
 
+        // Add menu item additional information
+        $this->menu = $this->setSelected($this->menu);
+
+        if (! isset($config['full_menu']) || $config['full_menu'] == false) {
             // Trim the non-needed limbs off the menu
             $this->menu = $this->trimMenu($this->menu);
         }
@@ -140,16 +145,9 @@ class ParseMenu implements ParserInterface
 
         // Loop through each menu item
         foreach ($menu as $item) {
-            // Default each menu item to not-selected
-            $item['is_selected'] = false;
 
             // If this menu item is found in the path
             if (in_array($item['menu_item_id'], $this->path)) {
-                // This item should be in the selected path
-                $item['is_selected'] = true;
-
-                // Set the meta information
-                $this->meta['has_selected'] = true;
 
                 // If there is a submenu trim it too
                 if (! empty($item['submenu'])) {
@@ -268,5 +266,36 @@ class ParseMenu implements ParserInterface
         }
 
         return false;
+    }
+
+    private function setSelected(array $menu)
+    {
+        // Start with the blank new menu
+        $full_menu = array();
+
+        // Loop through each menu item
+        foreach ($menu as $item) {
+            // Default each menu item to not-selected
+            $item['is_selected'] = false;
+
+            // If this menu item is found in the path
+            if (in_array($item['menu_item_id'], $this->path)) {
+                // This item should be in the selected path
+                $item['is_selected'] = true;
+
+                // Set the meta information
+                $this->meta['has_selected'] = true;
+            }
+
+            // If there is a submenu trim it too
+            if (!empty($item['submenu'])) {
+                $item['submenu'] = $this->setSelected($item['submenu']);
+            }
+
+            // Add this item to the newly trimmed menu
+            $full_menu[] = $item;
+        }
+
+        return $full_menu;
     }
 }

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -268,6 +268,10 @@ class ParseMenu implements ParserInterface
         return false;
     }
 
+    /**
+     * @param array $menu
+     * @return array
+     */
     private function setSelected(array $menu)
     {
         // Start with the blank new menu
@@ -287,12 +291,12 @@ class ParseMenu implements ParserInterface
                 $this->meta['has_selected'] = true;
             }
 
-            // If there is a submenu trim it too
+            // If there is a sub menu, setSelected state on those items
             if (!empty($item['submenu'])) {
                 $item['submenu'] = $this->setSelected($item['submenu']);
             }
 
-            // Add this item to the newly trimmed menu
+            // Add this item into the menu being formed
             $full_menu[] = $item;
         }
 

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -125,7 +125,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function noConfigNoChange()
+    public function noConfigWillTrimAllButFirstLevel()
     {
         // No configuration options
         $config = array(
@@ -134,8 +134,9 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         // Parse the menu
         $parsed = $this->parser->parse($this->menu, $config);
 
-        // There should be no different in the base and resulting array
-        $this->assertEmpty($this->arrayRecursiveDiff($parsed['menu'], $this->menu));
+        foreach($parsed['menu'] as $item) {
+            $this->assertCount(0, $item['submenu']);
+        }
 
         // Meta information should be default
         $this->assertFalse($parsed['meta']['has_selected']);
@@ -187,6 +188,36 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function noPageSelectedShouldReturnFullMenu()
+    {
+        // No configuration options
+        $config = array(
+            'page_selected' => 8,
+            'full_menu' => true,
+        );
+
+        // Parse the menu
+        $selected_menu = $this->parser->parse($this->menu, $config);
+
+        // Verify the first menu item no longer has submenu items to display
+        $this->assertCount(count($this->menu[0]['submenu']), $selected_menu['menu'][0]['submenu']);
+
+
+        // No configuration options
+        $config = array(
+            'full_menu' => true,
+        );
+
+        // Parse the menu
+        $full_menu = $this->parser->parse($this->menu, $config);
+
+        // Verify the first menu item no longer has submenu items to display
+        $this->assertCount(count($this->menu[0]['submenu']), $full_menu['menu'][0]['submenu']);
+    }
+
+    /**
+     * @test
+     */
     public function pageNotFoundAndNothingSelected()
     {
         // Determine a page to be selected
@@ -204,6 +235,25 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($parsed['meta']['has_selected']);
         $this->assertEmpty($parsed['meta']['path']);
+    }
+
+    /**
+     * @test
+     */
+    public function isSelectedKeyExistsOnNoPageSelectedConfig()
+    {
+        // Determine a page to be selected
+        $config = array(
+            //'page_selected' => 999
+        );
+
+        // Parse the menu based on the config
+        $parsed = $this->parser->parse($this->menu, $config);
+
+        // Verify no main menu items have the is_selected flag
+        foreach ($parsed['menu'] as $item) {
+            $this->assertArrayHasKey('is_selected', $item);
+        }
     }
 
     /**

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -135,7 +135,11 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         foreach($parsed['menu'] as $item) {
+            // No sub menus should be found
             $this->assertCount(0, $item['submenu']);
+
+            // is_selected should be applied to all menu items
+            $this->assertArrayHasKey('is_selected', $item);
         }
 
         // Meta information should be default
@@ -202,7 +206,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         // Verify the first menu item no longer has submenu items to display
         $this->assertCount(count($this->menu[0]['submenu']), $selected_menu['menu'][0]['submenu']);
 
-
         // No configuration options
         $config = array(
             'full_menu' => true,
@@ -235,25 +238,6 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($parsed['meta']['has_selected']);
         $this->assertEmpty($parsed['meta']['path']);
-    }
-
-    /**
-     * @test
-     */
-    public function isSelectedKeyExistsOnNoPageSelectedConfig()
-    {
-        // Determine a page to be selected
-        $config = array(
-            //'page_selected' => 999
-        );
-
-        // Parse the menu based on the config
-        $parsed = $this->parser->parse($this->menu, $config);
-
-        // Verify no main menu items have the is_selected flag
-        foreach ($parsed['menu'] as $item) {
-            $this->assertArrayHasKey('is_selected', $item);
-        }
     }
 
     /**


### PR DESCRIPTION
## Features
- `is_selected` attribute now being added to every menu item
- `full_menu` config added to return the full menu, regardless if a page is selected. Default behavior of trimming still in place for backwards compatibility.
