### PR TITLE
Get an array of Breadcrumbs from a Parsed Menu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "source": "https://github.com/waynestate/parse-menu"
     },
     "require": {
-        "php": ">=5.5.9",
-        "illuminate/support": "~5.2.0"
+        "php": ">=5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "source": "https://github.com/waynestate/parse-menu"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.5.9",
+        "illuminate/support": "~5.2.0",
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.2.0",
+        "illuminate/support": "~5.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -102,12 +102,13 @@ class ParseMenu implements ParserInterface
      * @param $menu
      * @return mixed
      */
-    public function getBreadCrumbs($menu){
+    public function getBreadCrumbs($menu)
+    {
         $breadcrumbs = [];
 
-        foreach($menu['meta']['path'] as $menu_item_id){
+        foreach ($menu['meta']['path'] as $menu_item_id) {
             $array_path[] = array_shift($menu['meta']['path']);
-            $crumb = array_get($menu['menu'], implode('.submenu.', $array_path));
+            $crumb = static::array_get($menu['menu'], implode('.submenu.', $array_path));
             $crumb['submenu'] = null;
             $breadcrumbs[] = $crumb;
         }
@@ -318,5 +319,33 @@ class ParseMenu implements ParserInterface
         }
 
         return $full_menu;
+    }
+
+    /**
+     * Get an item from an array using "dot" notation.
+     *
+     * @param  string $key
+     * @param  mixed $default
+     * @return mixed
+     */
+    private static function array_get($array, $key, $default = null)
+    {
+        if (!is_array($array)) {
+            return value($default);
+        }
+        if (is_null($key)) {
+            return $array;
+        }
+        if (array_key_exists($key, $array)) {
+            return $array[$key];
+        }
+        foreach (explode('.', $key) as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return value($default);
+            }
+        }
+        return $array;
     }
 }

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -120,6 +120,7 @@ class ParseMenu implements ParserInterface
     {
         $breadcrumbs = array();
 
+        // Loop through the path array and pull out each of the menu_item_ids from within the $menu['menu'] array
         foreach ((array)$menu['meta']['path'] as $menu_item_id) {
             $array_path[] = $menu_item_id;
             $crumb = static::array_get($menu['menu'], implode('.submenu.', $array_path));

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -99,6 +99,23 @@ class ParseMenu implements ParserInterface
     }
 
     /**
+     * @param $menu
+     * @return mixed
+     */
+    public function getBreadCrumbs($menu){
+        $breadcrumbs = [];
+
+        foreach($menu['meta']['path'] as $menu_item_id){
+            $array_path[] = array_shift($menu['meta']['path']);
+            $crumb = array_get($menu['menu'], implode('.submenu.', $array_path));
+            $crumb['submenu'] = null;
+            $breadcrumbs[] = $crumb;
+        }
+
+        return $breadcrumbs;
+    }
+
+    /**
      * @param array $menu
      * @param $page_id
      * @return array

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -104,7 +104,7 @@ class ParseMenu implements ParserInterface
      */
     public function getBreadCrumbs($menu)
     {
-        $breadcrumbs = [];
+        $breadcrumbs = array();
         foreach ((array)$menu['meta']['path'] as $menu_item_id) {
             $array_path[] = array_shift($menu['meta']['path']);
             $crumb = static::array_get($menu['menu'], implode('.submenu.', $array_path));

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -124,7 +124,7 @@ class ParseMenu implements ParserInterface
         foreach ((array)$menu['meta']['path'] as $menu_item_id) {
             $array_path[] = $menu_item_id;
             $crumb = static::array_get($menu['menu'], implode('.submenu.', $array_path));
-            $crumb['submenu'] = null;
+            $crumb['submenu'] = array();
             $breadcrumbs[] = $crumb;
         }
 

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -159,7 +159,7 @@ class ParseMenu implements ParserInterface
             }
 
             // Add this item to the newly trimmed menu
-            $path_menu[] = $item;
+            $path_menu[$item['menu_item_id']] = $item;
         }
 
         // Return the trimmed menu
@@ -230,7 +230,7 @@ class ParseMenu implements ParserInterface
                 }
 
                 // If in bounds, add the item to the new menu
-                $slice_menu[] = $item;
+                $slice_menu[$item['menu_item_id']] = $item;
             }
         }
 
@@ -297,7 +297,7 @@ class ParseMenu implements ParserInterface
             }
 
             // Add this item into the menu being formed
-            $full_menu[] = $item;
+            $full_menu[$item['menu_item_id']] = $item;
         }
 
         return $full_menu;

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -105,8 +105,7 @@ class ParseMenu implements ParserInterface
     public function getBreadCrumbs($menu)
     {
         $breadcrumbs = [];
-
-        foreach ($menu['meta']['path'] as $menu_item_id) {
+        foreach ((array)$menu['meta']['path'] as $menu_item_id) {
             $array_path[] = array_shift($menu['meta']['path']);
             $crumb = static::array_get($menu['menu'], implode('.submenu.', $array_path));
             $crumb['submenu'] = null;

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -98,6 +98,20 @@ class ParseMenu implements ParserInterface
         );
     }
 
+
+    /**
+     * @param $breadcrumbs
+     * @param $menu_item
+     * @return mixed
+     */
+    public function prependBreadCrumb($breadcrumbs, $menu_item)
+    {
+        // add menu_item to the breadcrumbs array and return it
+        array_unshift($breadcrumbs, $menu_item);
+
+        return $breadcrumbs;
+    }
+
     /**
      * @param $menu
      * @return mixed
@@ -105,8 +119,9 @@ class ParseMenu implements ParserInterface
     public function getBreadCrumbs($menu)
     {
         $breadcrumbs = array();
+
         foreach ((array)$menu['meta']['path'] as $menu_item_id) {
-            $array_path[] = array_shift($menu['meta']['path']);
+            $array_path[] = $menu_item_id;
             $crumb = static::array_get($menu['menu'], implode('.submenu.', $array_path));
             $crumb['submenu'] = null;
             $breadcrumbs[] = $crumb;

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -260,7 +260,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function breadcrumbsKeysShouldBeInPath()
+    public function breadcrumbsMenuItemIDShouldBeInPath()
     {
         // No configuration options
         $config = array(
@@ -272,7 +272,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
 
         // # of breadcrumbs in $breadcrumbs is the same as the parsed path count
         foreach((array)$breadcrumbs as $key => $crumb){
-            $this->assertArrayHasKey($key, $parsed['meta']['path']);
+            $this->assertContains($crumb['menu_item_id'], $parsed['meta']['path']);
         }
     }
 

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -245,7 +245,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
      */
     public function breadcrumbsShouldMatchPathCount()
     {
-        // No configuration options
+        // Set a selected page
         $config = array(
             'page_selected' => 9,
         );
@@ -262,7 +262,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
      */
     public function breadcrumbsMenuItemIDShouldBeInPath()
     {
-        // No configuration options
+        // Set a selected page
         $config = array(
             'page_selected' => 9,
         );
@@ -281,7 +281,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
      */
     public function prependBreadCrumbsShouldAddBreadCrumb()
     {
-        // No configuration options
+        // Set a selected page
         $config = array(
             'page_selected' => 9,
         );
@@ -289,6 +289,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
         $breadcrumbs = $this->parser->getBreadCrumbs($parsed);
 
+        // Create crumb for the root
         $root_crumb = array(
                 'menu_item_id' => 11,
                 'menu_id' => 1,
@@ -299,6 +300,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 'submenu' => null
         );
 
+        // Get the breadcrumbs with the added crumb
         $breadcrumbs = $this->parser->prependBreadCrumb($breadcrumbs, $root_crumb);
 
         $this->assertEquals($breadcrumbs[0], $root_crumb);

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -243,6 +243,42 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function breadcrumbsShouldMatchPathCount()
+    {
+        // No configuration options
+        $config = array(
+            'page_selected' => 9,
+        );
+
+        $parsed = $this->parser->parse($this->menu, $config);
+        $breadcrumbs = $this->parser->getBreadCrumbs($parsed);
+
+        // # of breadcrumbs in $breadcrumbs is the same as the parsed path count
+        $this->assertCount(count($parsed['meta']['path']), $breadcrumbs);
+    }
+
+    /**
+     * @test
+     */
+    public function breadcrumbsKeysShouldBeInPath()
+    {
+        // No configuration options
+        $config = array(
+            'page_selected' => 9,
+        );
+
+        $parsed = $this->parser->parse($this->menu, $config);
+        $breadcrumbs = $this->parser->getBreadCrumbs($parsed);
+
+        // # of breadcrumbs in $breadcrumbs is the same as the parsed path count
+        foreach((array)$breadcrumbs as $key => $crumb){
+            $this->assertArrayHasKey($key, $parsed['meta']['path']);
+        }
+    }
+
+    /**
+     * @test
+     */
     public function shouldLimitToOneLevelDeep()
     {
         // Determine a page to be selected

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -161,7 +161,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Verify menu item has a boolean flag
-        $this->assertTrue($parsed['menu'][0]['is_selected']);
+        $this->assertTrue($parsed['menu'][1]['is_selected']);
 
         // Verify meta information matches
         $this->assertTrue($parsed['meta']['has_selected']);
@@ -182,7 +182,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->menu, $config);
 
         // Verify the first menu item no longer has submenu items to display
-        $this->assertCount(0, $parsed['menu'][0]['submenu']);
+        $this->assertCount(0, $parsed['menu'][1]['submenu']);
 
         // Verify meta information matches
         $this->assertTrue($parsed['meta']['has_selected']);
@@ -204,7 +204,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $selected_menu = $this->parser->parse($this->menu, $config);
 
         // Verify the first menu item no longer has submenu items to display
-        $this->assertCount(count($this->menu[0]['submenu']), $selected_menu['menu'][0]['submenu']);
+        $this->assertCount(count($this->menu[0]['submenu']), $selected_menu['menu'][1]['submenu']);
 
         // No configuration options
         $config = array(
@@ -215,7 +215,7 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $full_menu = $this->parser->parse($this->menu, $config);
 
         // Verify the first menu item no longer has submenu items to display
-        $this->assertCount(count($this->menu[0]['submenu']), $full_menu['menu'][0]['submenu']);
+        $this->assertCount(count($this->menu[0]['submenu']), $full_menu['menu'][1]['submenu']);
     }
 
     /**

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -279,6 +279,34 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function prependBreadCrumbsShouldAddBreadCrumb()
+    {
+        // No configuration options
+        $config = array(
+            'page_selected' => 9,
+        );
+
+        $parsed = $this->parser->parse($this->menu, $config);
+        $breadcrumbs = $this->parser->getBreadCrumbs($parsed);
+
+        $root_crumb = array(
+                'menu_item_id' => 11,
+                'menu_id' => 1,
+                'page_id' => 11,
+                'parent_id' => 0,
+                'is_active' => true,
+                'display_name' => 'BreadCrumb',
+                'submenu' => null
+        );
+
+        $breadcrumbs = $this->parser->prependBreadCrumb($breadcrumbs, $root_crumb);
+
+        $this->assertEquals($breadcrumbs[0], $root_crumb);
+    }
+
+    /**
+     * @test
+     */
     public function shouldLimitToOneLevelDeep()
     {
         // Determine a page to be selected


### PR DESCRIPTION
@robertvrabel @nickdenardis 

We talked about it before having parse-menu be able to return the breadcrumbs.

We'll need to go over this, but this starts it.
