### PR TITLE
Only allow unique menu_item_ids to be part of the path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-menu",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "type": "library",
     "description": "Parse menus from the Wayne State University API",
     "keywords": ["array","parser"],

--- a/src/ParseMenu.php
+++ b/src/ParseMenu.php
@@ -159,7 +159,7 @@ class ParseMenu implements ParserInterface
             }
 
             // If this individual item matches the page, keep track of it
-            if ($item['page_id'] == $page_id) {
+            if ($item['page_id'] == $page_id && !in_array($item['menu_item_id'], $path)) {
                 $path[] = $item['menu_item_id'];
             }
         }

--- a/tests/ParseMenuTest.php
+++ b/tests/ParseMenuTest.php
@@ -120,6 +120,84 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
                 'submenu' => array(),
             ),
         );
+
+        // Stub
+        $this->doublePageMenu = array(
+            array(
+                'menu_item_id' => 1,
+                'menu_id' => 1,
+                'page_id' => 1,
+                'parent_id' => 0,
+                'is_active' => true,
+                'display_name' => 'First',
+                'submenu' => array(
+                    array(
+                        'menu_item_id' => 3,
+                        'menu_id' => 1,
+                        'page_id' => 2,
+                        'parent_id' => 1,
+                        'is_active' => true,
+                        'display_name' => 'Nest One',
+                        'submenu' => array(),
+                    ),
+                    array(
+                        'menu_item_id' => 4,
+                        'menu_id' => 1,
+                        'page_id' => 3,
+                        'parent_id' => 1,
+                        'is_active' => true,
+                        'display_name' => 'Nest Two',
+                        'submenu' => array(),
+                    ),
+                    array(
+                        'menu_item_id' => 5,
+                        'menu_id' => 1,
+                        'page_id' => 1,
+                        'parent_id' => 1,
+                        'is_active' => true,
+                        'display_name' => 'Nest Three',
+                        'submenu' => array(),
+                    ),
+                ),
+            ),
+            array(
+                'menu_item_id' => 2,
+                'menu_id' => 1,
+                'page_id' => 2,
+                'parent_id' => 0,
+                'is_active' => true,
+                'display_name' => 'Second',
+                'submenu' => array(
+                    array(
+                        'menu_item_id' => 6,
+                        'menu_id' => 1,
+                        'page_id' => 7,
+                        'parent_id' => 2,
+                        'is_active' => false,
+                        'display_name' => 'Two Nest One',
+                        'submenu' => array(),
+                    ),
+                    array(
+                        'menu_item_id' => 7,
+                        'menu_id' => 1,
+                        'page_id' => 8,
+                        'parent_id' => 2,
+                        'is_active' => false,
+                        'display_name' => 'Two Nest Two',
+                        'submenu' => array(),
+                    ),
+                ),
+            ),
+            array(
+                'menu_item_id' => 10,
+                'menu_id' => 1,
+                'page_id' => 11,
+                'parent_id' => 0,
+                'is_active' => true,
+                'display_name' => 'Third',
+                'submenu' => array(),
+            ),
+        );
     }
 
     /**
@@ -304,6 +382,22 @@ class ParseMenuTest extends PHPUnit_Framework_TestCase
         $breadcrumbs = $this->parser->prependBreadCrumb($breadcrumbs, $root_crumb);
 
         $this->assertEquals($breadcrumbs[0], $root_crumb);
+    }
+
+    /**
+     * @test
+     */
+    public function metaPathShouldAllowMultiplePageIDsPartOfTheTraversedPath()
+    {
+        // Set a selected page
+        $config = array(
+            'page_selected' => 1,
+        );
+
+        $parsed = $this->parser->parse($this->doublePageMenu, $config);
+
+        $path = array(0 => 1, 1 => 5);
+        $this->assertEquals($path, $parsed['meta']['path']);
     }
 
     /**


### PR DESCRIPTION
Make findPath more strict on adding the found menu_item_id to the path array. This makes sure that there are unique menu item id within the path[].

This will allow a root menu item link to a page_id and a child menu item link to the same page_id in the traversed path allowing for a root menu item not needing to be an actual page.